### PR TITLE
Disable `autoSubfolderIndex` in prerender options

### DIFF
--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -119,6 +119,7 @@ export default defineNuxtConfig(<Partial<DefineNuxtConfig>>{
   },
   nitro: {
     prerender: {
+      autoSubfolderIndex: false,
       crawlLinks: true,
       routes: ["/"]
     }


### PR DESCRIPTION
This fixes there being a trailing slash added by Cloudflare Pages and causing unneeded redirects.